### PR TITLE
ENHANCE: Enable partial satisfiability monitoring

### DIFF
--- a/eclogues-impl/app/api/Main.hs
+++ b/eclogues-impl/app/api/Main.hs
@@ -120,8 +120,6 @@ withPersist host port conf webLock zkErrors = do
             threadDelay . floor $ ((30 % Second) # micro Second :: Double)
         -- TODO: catch run error and reschedule
         enacter = forever . STM.atomically $ runSingleCommand conf
-
-    -- Configure threads ignoring monitoring if the relevant configuration is not provided
     hPutStrLn stderr $ "Starting server on " ++ host ++ ':':show port
     runConcurrently $ Concurrently (const (error "web failed") <$> web)
                   <|> Concurrently updater

--- a/eclogues-impl/test/Eclogues/Monitoring/ClusterSpec.hs
+++ b/eclogues-impl/test/Eclogues/Monitoring/ClusterSpec.hs
@@ -37,7 +37,7 @@ dep = forceName "dep"
 monitored :: Scheduler -> Cluster -> EitherError AppState
 monitored sched cluster = do
     state <- scheduler' sched
-    let monitor = updateSatisfiabilities cluster state
+    let monitor = updateSatisfiabilities (Just cluster) state
     scheduler state monitor
 
 testCluster :: Cluster
@@ -46,7 +46,7 @@ testCluster = [nodeResources fullResources]
 spec :: Spec
 spec = do
     describe "updateSatisfiabilities" $
-        it "should tag satisfiable jobs involving a dependency as Satisfiable" $
+        it "should tag unsatisfiable job involving an unsatisfiable dependency as unsatisfiable" $
             let createdJobs = do
                     createJob' $ isolatedJob  dep       overResources
                     createJob' $ dependentJob job [dep] overResources

--- a/eclogues-mock/src/Eclogues/State.hs
+++ b/eclogues-mock/src/Eclogues/State.hs
@@ -28,7 +28,7 @@ import Eclogues.Job (
       FailureReason (..), RunErrorReason (..), QueueStage (..), Stage (..)
     , isActiveStage, isTerminationStage, isOnScheduler, isQueueStage)
 import qualified Eclogues.Job as Job
-import Eclogues.Monitoring.Cluster (Cluster, jobDepSatisfy)
+import Eclogues.Monitoring.Cluster (Cluster, stagelessSatisfy)
 import Eclogues.Scheduling.Command (ScheduleCommand (..))
 import qualified Eclogues.State.Monad as ES
 import Eclogues.State.Monad (TS)
@@ -55,7 +55,7 @@ createJob uuid cluster spec = do
     existing <- ES.getJob name
     when (isJust existing) $ throwError JobNameUsed
     Sum activeDepCount <- execWriterT $ traverse_ (checkDep name) deps
-    satis <- maybe (pure Job.SatisfiabilityUnknown) (jobDepSatisfy spec) cluster
+    satis <- stagelessSatisfy cluster spec
     let jstage = if activeDepCount == 0
             then Queued LocalQueue
             else Waiting activeDepCount


### PR DESCRIPTION
This change enables partial satisfiability monitoring when no cluster information exists. Two cases where this is possible despite the absence of cluster information:
1) A job is known to be satisfiable because it is running on the scheduler.
2) A job is known to be unsatisfiable because one or more ofits dependencies are unsatisfiable.